### PR TITLE
refactoring removing ammo scripts

### DIFF
--- a/addons/arsenal/functions/fnc_addSelection.sqf
+++ b/addons/arsenal/functions/fnc_addSelection.sqf
@@ -1,17 +1,17 @@
 #include "script_component.hpp"
-params ["_unit","_grenades"];
-_vest = getArray (configFile >> "CfgWeapons" >> _grenades >> "vest");
+params ["_unit","_selection"];
+_vest = getArray (configFile >> "CfgWeapons" >> _selection >> "vest");
  { 
   (vestContainer player) addMagazineCargoGlobal [ _x select 0, _x select 1 ];
 player addMagazines [ _x select 0, 0 ]; 
 } foreach _vest;
-_uniform = getArray (configFile >> "CfgWeapons" >> _grenades >> "uniform");
+_uniform = getArray (configFile >> "CfgWeapons" >> _selection >> "uniform");
  
 { 
   (uniformContainer player) addMagazineCargoGlobal [ _x select 0, _x select 1 ];
 player addMagazines [ _x select 0, 0 ]; 
 } foreach _uniform;
-_bag = getArray (configFile >> "CfgWeapons" >> _grenades >> "bag");
+_bag = getArray (configFile >> "CfgWeapons" >> _selection >> "bag");
  
 { 
   (backpackContainer player) addMagazineCargoGlobal [ _x select 0, _x select 1 ];

--- a/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
+++ b/addons/arsenal/functions/fnc_onSelChangedLeft.sqf
@@ -290,7 +290,7 @@ switch (GVAR(currentLeftPanel)) do {
         ACE_Player setVariable  ["socomd_arsenal_nvg", _item];
         _nvgArray = ["SOCOMD_NVG","SOCOMD_NVG_GR","SOCOMD_NVG_GPNVG_WP_black","SOCOMD_NVG_GPNVG_GR_black" , "SOCOMD_NVG_AM", "SOCOMD_NVG_B", "SOCOMD_NVG_GR_B", "SOCOMD_NVG_AM_B", "SOCOMD_NVG_C", "SOCOMD_NVG_GR_C", "SOCOMD_NVG_AM_C", "SOCOMD_NVG_GPNVG_WP_black", "SOCOMD_NVG_GPNVG_GR_black"];
         _unitLoadout = getUnitLoadout GVAR(center);
-        if ((GVAR(currentItems) select 8) != _item) then {
+        if ((GVAR(currentItems) select 8) != "") then {
             // If item is attached, just changed the attached item
             if ((GVAR(currentItems) select 8) in _nvgArray) then {
                 ACE_Player linkItem _item;

--- a/addons/loadouts/configs/loadouts/default.hpp
+++ b/addons/loadouts/configs/loadouts/default.hpp
@@ -170,8 +170,8 @@ class SOCOMD_Commander {
         class Inventory {
             LOADOUT_VEST_ESSENTIALS
             LOADOUT_ITEM(ACRE_PRC152, 2)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
         };
     };
 
@@ -272,8 +272,8 @@ class SOCOMD_Leader {
         type = ITEM_VEST_PATROLLEADER;
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
             LOADOUT_ITEM(ACRE_PRC152, 2)
         };
     };
@@ -323,8 +323,8 @@ class SOCOMD_Rifleman {
         type = ITEM_VEST_RIFLEMAN;
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
         };
     };
     class Backpack {
@@ -332,9 +332,6 @@ class SOCOMD_Rifleman {
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
             LOADOUT_ITEM(ACE_EntrenchingTool, 1)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 4)
-            LOADOUT_ITEM(20Rnd_762x51_Mag, 2)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_BELT,1)
         };
     };
 };
@@ -366,8 +363,8 @@ class SOCOMD_Breacher {
         type = ITEM_VEST_BREACHER;
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
         };
     };
     class Backpack {
@@ -453,8 +450,8 @@ class SOCOMD_Sapper {
         type = ITEM_VEST_SAPPER;
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
         };
     };
 
@@ -544,8 +541,8 @@ class SOCOMD_Medic {
         type = ITEM_VEST_MEDIC;
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
         };
     };
 
@@ -683,8 +680,8 @@ class SOCOMD_AT {
         type = ITEM_VEST_AT;
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
         };
     };
 
@@ -774,8 +771,8 @@ class SOCOMD_Logistician {
         type = ITEM_VEST_RIFLEMAN;
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
-            LOADOUT_ITEM(ITEM_MAGAZINE_556, 6)
-            LOADOUT_ITEM(ITEM_MAGAZINE_556_TRACER, 2)
+            LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
+            
             LOADOUT_ITEM(SmokeShell, 3)
             LOADOUT_ITEM(ACRE_PRC152, 1)
             LOADOUT_ITEM(ACRE_PRC343, 1)

--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 2
 #define MINOR 0
-#define PATCHLVL 1
+#define PATCHLVL 2
 #define BUILD 0

--- a/addons/qstore/functions/fnc_SwitchUnitLoadout.sqf
+++ b/addons/qstore/functions/fnc_SwitchUnitLoadout.sqf
@@ -185,6 +185,8 @@ _unitLoadout set [9, _equipmentLoadout];
 _player setVariable ["SOCOMD_stashedGear", false];
 _player setVariable ["SOCOMD_hasDivingGear", false];
 [_player, _unitLoadout] call FUNC(SetUnitLoadout);
+
+ACE_Player setVariable  ["socomd_prev_weapons",[_primary,_secondary,_handgun]];
 [_player, _loadoutId,_unitConfig] call FUNC(UpdateArsenalContent);
 
 // Custom Arsenal code

--- a/addons/qstore/functions/fnc_UpdateArsenalContent.sqf
+++ b/addons/qstore/functions/fnc_UpdateArsenalContent.sqf
@@ -116,11 +116,16 @@ if ( typeName _isPrevInit == "ARRAY") then {
 };
 
 private _openedEh = ["socomd_arsenal_displayOpened", {
-    ACE_Player setVariable ["SOCOMD_prev_primary", primaryWeapon ACE_Player]
     params ["_display"];
-    _loadoutIdEH = ACE_Player getVariable ["SOCOMD_LOADOUTID","failed"];
+    private _loadoutIdEH = ACE_Player getVariable ["SOCOMD_LOADOUTID","failed"];
+    private _primaryWeapon = primaryWeapon ACE_Player;
+    private _secondaryWeapon = secondaryWeapon ACE_Player;
+    private _handgunWeapon = handgunWeapon ACE_Player;
+    ACE_Player setVariable  ["socomd_prev_arsenal_extras", (ACE_Player getVariable  ["socomd_arsenal_extras", "extras_none"])];
     
-    _disabledButtons = [
+    ACE_Player setVariable  ["socomd_prev_weapons",[_primaryWeapon,_secondaryWeapon,_handgunWeapon]];
+    
+    private _disabledButtons = [
         2022,   // IDC_buttonMap 
         2024,   // IDC_buttonGPS 
         2026,   // IDC_buttonRadio 
@@ -163,7 +168,7 @@ private _openedEh = ["socomd_arsenal_displayOpened", {
     
 }] call CBA_fnc_addEventHandler;
 private _removedRight = ["socomd_arsenal_rightPanelFilled", { 
-    _currentTab = currentNamespace getVariable "socomd_arsenal_currentLeftPanel";
+    private _currentTab = currentNamespace getVariable "socomd_arsenal_currentLeftPanel";
     switch(_currentTab) do {
         case 2010 :{ // uniform panel
            TOGGLE_RIGHT_PANEL_HIDE
@@ -177,20 +182,18 @@ private _removedRight = ["socomd_arsenal_rightPanelFilled", {
     };
 }] call CBA_fnc_addEventHandler;
 private _closedEh = ["socomd_arsenal_displayClosed", {
-    _extraItems = ACE_Player getVariable ["socomd_arsenal_extras","none"];
-    _grenadesOption = ACE_Player getVariable  ["socomd_arsenal_grenade", "default"];
+    private _extraItems = ACE_Player getVariable ["socomd_arsenal_extras","none"];
+    private _grenadesOption = ACE_Player getVariable  ["socomd_arsenal_grenade", "default"];
     // for some reason using _player inside here doesnt work. Done in this order so launcher ammo isn't deleted
+    private _primaryWeapon = primaryWeapon ACE_Player;
+    private _secondaryWeapon = secondaryWeapon ACE_Player;
+    private _handgunWeapon = handgunWeapon ACE_Player;
     [ACE_Player] call FUNC(removeAmmo);
-    [ACE_Player, primaryWeapon ACE_Player] call FUNC(addPrimaryAmmo);
-    [ACE_Player, secondaryWeapon ACE_Player] call FUNC(addSecondaryAmmo);
-    [ACE_Player, handgunWeapon ACE_Player] call FUNC(addHandgunAmmo);
+    [ACE_Player, _primaryWeapon] call FUNC(addPrimaryAmmo);
+    [ACE_Player, _secondaryWeapon] call FUNC(addSecondaryAmmo);
+    [ACE_Player, _handgunWeapon] call FUNC(addHandgunAmmo);
     [ACE_Player] call FUNC(cleanUpMagazines);
     [ACE_Player] call FUNC(addInventoryWeaponAmmo);
-    if(_grenadesOption != "default") then {
-        [ACE_Player,_grenadesOption] call socomd_arsenal_fnc_addSelection;
-    } else {
-        [ACE_Player] call FUNC(addGrenades);
-    };
     // [player] call SOCOMD_fnc_RefreshInsignia;
     if( _extraItems !=  "none" ) then  {
         [ACE_Player, _extraItems] call socomd_arsenal_fnc_addSelection;

--- a/addons/qstore/functions/fnc_removeAmmo.sqf
+++ b/addons/qstore/functions/fnc_removeAmmo.sqf
@@ -6,9 +6,7 @@ private _configFile = configFile >> "CfgLoadoutWeapons";
     if (isClass(_configFile >> _x)) then {
         private _ammo = getArray(_configFile >> _x >> "magazines");
         {
-            { 
-                for [{ _i = 0 }, { _i < (_x select 1) }, { _i = _i + 1 }] do { _player removeMagazine (_x select 0) }
-            } forEach _x;
+            for [{ _i = 0 }, { _i < (_x select 1) }, { _i = _i + 1 }] do { _player removeMagazine (_x select 0) }   
         } forEach _ammo;
     };
 } forEach [_primaryWeapon,_secondaryWeapon,_handgunWeapon];

--- a/addons/qstore/functions/fnc_removeAmmo.sqf
+++ b/addons/qstore/functions/fnc_removeAmmo.sqf
@@ -1,125 +1,24 @@
 #include "script_component.hpp"
 params ["_player"];
-
-_player  setVehicleAmmo 0;
-
-/*_currentPrimary = primaryWeapon _player;
-_secondary = secondaryWeapon _player;
-_handgun = handgunWeapon _player;
-_primaryMagazines = ["ACWP_30rnd_556x45_EPR_PMAG","ACWP_30rnd_556x45_M_PMAG","20Rnd_762x51_Mag","SOCOMD_200Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_150Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_200Rnd_TE4_Red_Tracer_556x45_M249_Pouch","SOCOMD_Item_Magazine_556x45_30Rnd_Tracer","SOCOMD_Item_Magazine_556x45_30Rnd", "1Rnd_HE_Grenade_shell", "UGL_FlareRed_F", "1Rnd_SmokeRed_Grenade_shell", "ACE_HuntIR_M203","SOCOMD_Item_Magazine_762x51_20Rnd","SOCOMD_Item_Magazine_556x45_200Rnd_Tracer","SOCOMD_Item_Magazine_762x51_100Rnd_Tracer","SOCOMD_200Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","rhs_mag_maaws_HEAT","rhs_mag_maaws_HE"];
-_primaryMagazines = [];
-_primaryMagazines = _primaryMagazines + getArray(configFile >> "CfgWeapons" >> _currentPrimary >> "magazines");
-_primaryMagazines = _primaryMagazines + getArray(configFile >> "CfgWeapons" >> _currentPrimary >> "EGLM" >> "magazines");
-_primaryMagazineWells = getArray(configFile >> "CfgWeapons" >> _currentPrimary >> "magazineWell");
-
-_secondaryMagazines = getArray(configFile >> "CfgWeapons" >> _secondary >> "magazines");
-
-
-//Get magazines from magazine wells
+ACE_Player getVariable  ["socomd_prev_weapons",[(primaryWeapon _player),(secondaryWeapon _player),(handgunWeapon _player)]] params ["_primaryWeapon","_secondaryWeapon","_handgunWeapon"];
+private _configFile = configFile >> "CfgLoadoutWeapons";
 {
-    _magazineWellConfig = (configFile >> "CfgMagazineWells" >> _x);
-    for "_i" from 0 to (count _magazineWellConfig) - 1 do {
-        _primaryMagazines = _primaryMagazines + getArray(_magazineWellConfig select _i);
+    if (isClass(_configFile >> _x)) then {
+        private _ammo = getArray(_configFile >> _x >> "magazines");
+        {
+            { 
+                for [{ _i = 0 }, { _i < (_x select 1) }, { _i = _i + 1 }] do { _player removeMagazine (_x select 0) }
+            } forEach _x;
+        } forEach _ammo;
     };
-}foreach(_primaryMagazineWells);
-
-//Remove primary magazines from player
-{
-    _primaryMagazine = _x;
-    {
-        if(_x isKindOf [_primaryMagazine, configFile >> 'CfgMagazines']) then {
-             _player removeMagazines _x;
-        };
-    }foreach(magazines _player);
-}foreach(_primaryMagazines);
-
-
-//Get magazines from magazine wells
-{
-    _magazineWellConfig = (configFile >> "CfgMagazineWells" >> _x);
-    for "_i" from 0 to (count _magazineWellConfig) - 1 do {
-        _secondaryMagazines = _secondaryMagazines + getArray(_magazineWellConfig select _i);
-    };
-}foreach(_secondaryMagazines);
-
-//Remove secondary magazines from player
-{
-    _secondaryMagazine = _x;
-    {
-        if(_x isKindOf [_secondaryMagazine, configFile >> 'CfgMagazines']) then {
-             _player removeMagazines _x;
-        };
-    }foreach(magazines _player);
-}foreach(_secondaryMagazines);
-
-
-
-_handgunMagazines = ["11Rnd_45ACP_Mag","ACWP_19Rnd_9x21_Mag_glock_sim","ACWP_19Rnd_9x21_Mag_glock","ACWP_13Rnd_9x21_Mag_HP","ACWP_18Rnd_9x21_Mag_USP"];
-_handgunMagazines = _handgunMagazines + getArray(configFile >> "CfgWeapons" >> _handgun >> "magazines");
-_handgunMagazines = _handgunMagazines + getArray(configFile >> "CfgWeapons" >> _handgun >> "EGLM" >> "magazines");
-_primaryMagazineWells = getArray(configFile >> "CfgWeapons" >> _handgun >> "magazineWell");
-
-//Get magazines from magazine wells
-{
-    _magazineWellConfig = (configFile >> "CfgMagazineWells" >> _x);
-    for "_i" from 0 to (count _magazineWellConfig) - 1 do {
-        _handgunMagazines = _handgunMagazines + getArray(_magazineWellConfig select _i);
-    };
-}foreach(_primaryMagazineWells);
-
-//Remove primary magazines from player
-{
-    _primaryMagazine = _x;
-    {
-        if(_x isKindOf [_primaryMagazine, configFile >> 'CfgMagazines']) then {
-             _player removeMagazines _x;
-        };
-    }foreach(magazines _player);
-}foreach(_handgunMagazines);
-
-
-//Set Primary Weapon
-_unitLoadout = getUnitLoadout _player;
-
-_primaryLoadout = _unitLoadout select 0;
-if(count _primaryLoadout <= 0) then {
-    _primaryLoadout = [_currentPrimary, "", "", "", [], [], ""];
-}
-else {
-    _primaryLoadout set [0, _currentPrimary];
-    _primaryLoadout set [4, []];
-    _primaryLoadout set [5, []];
-};
-
-_secondaryLoadout = _unitLoadout select 1;
-if(count _secondaryLoadout <= 0) then {
-    _secondaryLoadout = [_secondary, "", "", "", [], [], ""];
-}
-else {
-    _secondaryLoadout set [0, _secondary];
-    
-    if(isNumber( _loadoutWeaponConfig >> "startLoaded") && (getNumber( _loadoutWeaponConfig >> "startLoaded") == 1)) then {
-        _secondaryLoadout set [4, [((_loadoutMagazines) select 0 ) select 0,1000000]];
-    } else {
-        _secondaryLoadout set [4, []];
-    };
-    _secondaryLoadout set [5, []];
-};
-
-    _loadoutWeaponConfig = (configFile >> "CfgLoadoutWeapons" >> _handgun);
-_loadoutMagazines = getArray (_loadoutWeaponConfig >> "magazines");
-_handgunLoadout = _unitLoadout select 2;
-if(count _handgunLoadout <= 0) then {
-    _handgunLoadout = [_handgun, "", "", "", [((_loadoutMagazines) select 0 ) select 0,1000000], [], ""];
-} else {
-    _handgunLoadout set [0, _handgun];
-    _handgunLoadout set [4, [((_loadoutMagazines) select 0 ) select 0,1000000]];
-    _handgunLoadout set [5, [ ] ];
-};
-
-_unitLoadout set [0, _primaryLoadout];
-_unitLoadout set [1, _secondaryLoadout];
-_unitLoadout set [2, _handgunLoadout];
-
-
-[_player, _unitLoadout] call FUNC(SetUnitLoadout);*/
+} forEach [_primaryWeapon,_secondaryWeapon,_handgunWeapon];
+private _extraAmmo = _player getVariable  ["socomd_prev_arsenal_extras", "extras_none"]; 
+private _extraAmmoCfg = configFile >> "CfgWeapons" >> _extraAmmo; 
+private _extraUniform = getArray(_extraAmmoCfg >> "uniform"); 
+private _extraVest = getArray(_extraAmmoCfg >> "vest"); 
+private _extraBag = getArray(_extraAmmoCfg >> "bag"); 
+{ 
+    { 
+        for [{ _i = 0 }, { _i < (_x select 1) }, { _i = _i + 1 }] do { _player removeMagazine (_x select 0) }
+    } forEach _x;
+} forEach [_extraUniform, _extraVest, _extraBag]; 

--- a/tools/make.py
+++ b/tools/make.py
@@ -74,7 +74,7 @@ dssignfile = ""
 prefix = "socomd"
 pbo_name_prefix = "socomd_"
 signature_blacklist = []
-importantFiles = ["mod.cpp", "README.md", "AUTHORS.txt", "LICENSE"]
+importantFiles = ["mod.cpp","logo_socomd_ca.paa", "README.md", "AUTHORS.txt", "LICENSE"]
 versionFiles = ["mod.cpp", "README.md"]
 
 ciBuild = False # Used for CI builds


### PR DESCRIPTION
**When merged this pull request will:**
- changes how ammo is removed from the player, the assigned magazines has shifted in perspective from a "maximum" amount of magazines, to a "minimum" amount
```
- looks at the weapons the player had equipped upon opening the arsenal
- looks up the CFGLoadoutWeapons entry for the weapon, removes the predetermined amount
- Same method is used for the Rifleman's extras
```

This allows players to grab additional ammo from other people, or for other guns while making sure that a player only has a minimum amount of ammo, not caring about any extra that they have

This should also resolve any issues of players having equipment being eaten from the qstore
