### PR TITLE
Fix old references to kat in medical loadouts

### DIFF
--- a/addons/loadouts/configs/loadouts/afp.hpp
+++ b/addons/loadouts/configs/loadouts/afp.hpp
@@ -214,37 +214,7 @@ class SOCOMD_AFP_Medic {
         type = ITEM_BACKPACK_MEDIC;
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
-            LOADOUT_ITEM(SOCOMD_booboo, 1)
-            LOADOUT_ITEM(SOCOMD_shears, 1)
-            LOADOUT_ITEM(ACE_packingBandage, 0)          //Remove
-            LOADOUT_ITEM(ACE_fieldDressing, 20)          //Israeli Bandage
-            LOADOUT_ITEM(SOCOMD_triangleban, 3)          //Israeli Bandage
-            LOADOUT_ITEM(ACE_epinephrine, 0)              //Remove
-            LOADOUT_ITEM(ACE_morphine, 0)                  //Remove
-            LOADOUT_ITEM(ACE_personalAidKit, 0)            //Remove
-            LOADOUT_ITEM(ACE_salineIV_500, 0)             //Remove
-            LOADOUT_ITEM(SOCOMD_cascard, 2)
-            LOADOUT_ITEM(ACE_elasticBandage, 20)        //Elastic Bandage
-            LOADOUT_ITEM(ACE_quikclot, 25)                //Quikclot
-            LOADOUT_ITEM(KAT_ChestSeal, 6)                //Hyfin Chest Seal
-            LOADOUT_ITEM(SOCOMD_nargloves, 10)
-            LOADOUT_ITEM(ACE_tourniquet, 6)                //Tourniquet
-            LOADOUT_ITEM(SOCOMD_Epinephrine, 10)        //Epinephrine Ampoule
-            LOADOUT_ITEM(SOCOMD_naloxone, 2)                //Naloxone Ampoule
-            LOADOUT_ITEM(SOCOMD_fentanyl, 8)                //Fentanyl Ampoule
-            LOADOUT_ITEM(SOCOMD_ketamine, 8)                    //Ketamine Ampoule
-            LOADOUT_ITEM(SOCOMD_Apap, 10)                //Paracetamol
-            LOADOUT_ITEM(SOCOMD_Tetra, 5)                //Paracetamol
-            LOADOUT_ITEM(ACE_bloodIV_500, 5)            //Blood
-            LOADOUT_ITEM(SOCOMD_notes, 0)
-            LOADOUT_ITEM(KAT_guedel, 9)                    //Nasopharangeal Airway
-            LOADOUT_ITEM(KAT_larynx, 6)                    //Laryngeal Mask Airway
-            LOADOUT_ITEM(KAT_accuvac, 1)                //Medical Suction
-            LOADOUT_ITEM(KAT_Pulseoximeter, 4)            //Pulseoximeter
-            LOADOUT_ITEM(SOCOMD_NDC, 6)                    //14 Gauge needle
-            LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
-            LOADOUT_ITEM(ACE_surgicalKit, 8)            //Surgical Kit
-            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
+            LOADOUT_BACKPACK_MEDIC
         };
     };
 };

--- a/addons/loadouts/configs/loadouts/afp.hpp
+++ b/addons/loadouts/configs/loadouts/afp.hpp
@@ -29,7 +29,7 @@ class SOCOMD_AFP_Leader {
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
             LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
-            
+
             LOADOUT_ITEM(ACRE_PRC152, 2)
         };
     };
@@ -78,7 +78,7 @@ class SOCOMD_AFP_Rifleman {
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
             LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
-            
+
         };
     };
     class Backpack {
@@ -118,7 +118,7 @@ class SOCOMD_AFP_Breacher {
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
             LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
-            
+
         };
     };
     class Backpack {
@@ -206,7 +206,7 @@ class SOCOMD_AFP_Medic {
         class Inventory    {
             LOADOUT_VEST_ESSENTIALS
             LOADOUT_ITEM(ITEM_MAGAZINE_556, 8)
-            
+
         };
     };
 
@@ -244,7 +244,7 @@ class SOCOMD_AFP_Medic {
             LOADOUT_ITEM(SOCOMD_NDC, 6)                    //14 Gauge needle
             LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
             LOADOUT_ITEM(ACE_surgicalKit, 8)            //Surgical Kit
-            LOADOUT_ITEM(kat_AED, 1)        //Defibrillator
+            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
         };
     };
 };

--- a/addons/loadouts/configs/loadouts/default.hpp
+++ b/addons/loadouts/configs/loadouts/default.hpp
@@ -104,6 +104,40 @@
     LOADOUT_ITEM(ACE_fieldDressing, 0) \
     LOADOUT_ITEM(SOCOMD_VPN, 1)
 
+#define LOADOUT_BACKPACK_MEDIC \
+    LOADOUT_ITEM(SOCOMD_booboo, 1)\
+    LOADOUT_ITEM(SOCOMD_shears, 1)\
+    LOADOUT_ITEM(ACE_packingBandage, 0)\
+    LOADOUT_ITEM(ACE_fieldDressing, 20)\
+    LOADOUT_ITEM(SOCOMD_triangleban, 3)\
+    LOADOUT_ITEM(ACE_epinephrine, 0)\
+    LOADOUT_ITEM(ACE_morphine, 0)\
+    LOADOUT_ITEM(ACE_personalAidKit, 0)\
+    LOADOUT_ITEM(ACE_salineIV_500, 0)\
+    LOADOUT_ITEM(SOCOMD_cascard, 2)\
+    LOADOUT_ITEM(ACE_elasticBandage, 20)  \
+    LOADOUT_ITEM(ACE_quikclot, 25)        \
+    LOADOUT_ITEM(ACE_chestSeal, 6)        \
+    LOADOUT_ITEM(SOCOMD_nargloves, 10)\
+    LOADOUT_ITEM(ACE_tourniquet, 6)       \
+    LOADOUT_ITEM(SOCOMD_Epinephrine, 10)  \
+    LOADOUT_ITEM(SOCOMD_naloxone, 2)      \
+    LOADOUT_ITEM(SOCOMD_fentanyl, 8)      \
+    LOADOUT_ITEM(SOCOMD_ketamine, 8)      \
+    LOADOUT_ITEM(SOCOMD_Apap, 10)         \
+    LOADOUT_ITEM(SOCOMD_Tetra, 5)         \
+    LOADOUT_ITEM(ACE_bloodIV_500, 5)      \
+    LOADOUT_ITEM(SOCOMD_notes, 0)\
+    LOADOUT_ITEM(ACE_basicAirway, 9)      \
+    LOADOUT_ITEM(ACE_advancedAirway, 6)   \
+    LOADOUT_ITEM(ACE_pocketBVM, 1)        \
+    LOADOUT_ITEM(ACE_pulseOximeter, 4)    \
+    LOADOUT_ITEM(SOCOMD_NDC, 6)           \
+    LOADOUT_ITEM(SOCOMD_VPN, 30)          \
+    LOADOUT_ITEM(ACE_surgicalKit, 8)      \
+    LOADOUT_ITEM(socomd_defib_AED, 1)     \
+    LOADOUT_ITEM(ACE_bodyBag, 2)\
+
 //////////////////////////////////////////////////////////////////////
 //Individual loadout items
 //Contents shared by individual loadouts common to every Qstore
@@ -550,38 +584,7 @@ class SOCOMD_Medic {
         type = ITEM_BACKPACK_MEDIC;
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
-            LOADOUT_ITEM(SOCOMD_booboo, 1)
-            LOADOUT_ITEM(SOCOMD_shears, 1)
-            LOADOUT_ITEM(ACE_packingBandage, 0)          //Remove
-            LOADOUT_ITEM(ACE_fieldDressing, 20)          //Israeli Bandage
-            LOADOUT_ITEM(SOCOMD_triangleban, 3)          //Israeli Bandage
-            LOADOUT_ITEM(ACE_epinephrine, 0)              //Remove
-            LOADOUT_ITEM(ACE_morphine, 0)                  //Remove
-            LOADOUT_ITEM(ACE_personalAidKit, 0)            //Remove
-            LOADOUT_ITEM(ACE_salineIV_500, 0)             //Remove
-            LOADOUT_ITEM(SOCOMD_cascard, 2)
-            LOADOUT_ITEM(ACE_elasticBandage, 20)        //Elastic Bandage
-            LOADOUT_ITEM(ACE_quikclot, 25)                //Quikclot
-            LOADOUT_ITEM(ACE_chestSeal, 6)                //Hyfin Chest Seal
-            LOADOUT_ITEM(SOCOMD_nargloves, 10)
-            LOADOUT_ITEM(ACE_tourniquet, 6)                //Tourniquet
-            LOADOUT_ITEM(SOCOMD_Epinephrine, 10)        //Epinephrine Ampoule
-            LOADOUT_ITEM(SOCOMD_naloxone, 2)                //Naloxone Ampoule
-            LOADOUT_ITEM(SOCOMD_fentanyl, 8)                //Fentanyl Ampoule
-            LOADOUT_ITEM(SOCOMD_ketamine, 8)                    //Ketamine Ampoule
-            LOADOUT_ITEM(SOCOMD_Apap, 10)                //Paracetamol
-            LOADOUT_ITEM(SOCOMD_Tetra, 5)                //Paracetamol
-            LOADOUT_ITEM(ACE_bloodIV_500, 5)            //Blood
-            LOADOUT_ITEM(SOCOMD_notes, 0)
-            LOADOUT_ITEM(ACE_basicAirway, 9)                    //Nasopharangeal Airway
-            LOADOUT_ITEM(ACE_advancedAirway, 6)                    //Laryngeal Mask Airway
-            LOADOUT_ITEM(ACE_pocketBVM, 1)                //Airway help
-            LOADOUT_ITEM(ACE_pulseOximeter, 4)            //Pulseoximeter
-            LOADOUT_ITEM(SOCOMD_NDC, 6)                    //14 Gauge needle
-            LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
-            LOADOUT_ITEM(ACE_surgicalKit, 8)            //Surgical Kit
-            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
-            LOADOUT_ITEM(ACE_bodyBag, 2)
+            LOADOUT_BACKPACK_MEDIC
         };
     };
 };

--- a/addons/loadouts/configs/loadouts/loadouts_lowvis.hpp
+++ b/addons/loadouts/configs/loadouts/loadouts_lowvis.hpp
@@ -315,37 +315,7 @@ class SOCOMD_LOWVIS_Medic {
         type = ITEM_BACKPACK_MEDIC;
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
-            LOADOUT_ITEM(SOCOMD_booboo, 1)
-            LOADOUT_ITEM(SOCOMD_shears, 1)
-            LOADOUT_ITEM(ACE_packingBandage, 0)          //Remove
-            LOADOUT_ITEM(ACE_fieldDressing, 20)          //Israeli Bandage
-            LOADOUT_ITEM(SOCOMD_triangleban, 3)          //Israeli Bandage
-            LOADOUT_ITEM(ACE_epinephrine, 0)              //Remove
-            LOADOUT_ITEM(ACE_morphine, 0)                  //Remove
-            LOADOUT_ITEM(ACE_personalAidKit, 0)            //Remove
-            LOADOUT_ITEM(ACE_salineIV_500, 0)             //Remove
-            LOADOUT_ITEM(SOCOMD_cascard, 2)
-            LOADOUT_ITEM(ACE_elasticBandage, 20)        //Elastic Bandage
-            LOADOUT_ITEM(ACE_quikclot, 25)                //Quikclot
-            LOADOUT_ITEM(ACE_chestSeal, 6)                //Hyfin Chest Seal
-            LOADOUT_ITEM(SOCOMD_nargloves, 10)
-            LOADOUT_ITEM(ACE_tourniquet, 6)                //Tourniquet
-            LOADOUT_ITEM(SOCOMD_Epinephrine, 10)        //Epinephrine Ampoule
-            LOADOUT_ITEM(SOCOMD_naloxone, 2)                //Naloxone Ampoule
-            LOADOUT_ITEM(SOCOMD_fentanyl, 8)                //Fentanyl Ampoule
-            LOADOUT_ITEM(SOCOMD_ketamine, 8)                    //Ketamine Ampoule
-            LOADOUT_ITEM(SOCOMD_Apap, 10)                //Paracetamol
-            LOADOUT_ITEM(SOCOMD_Tetra, 5)                //Paracetamol
-            LOADOUT_ITEM(ACE_bloodIV_500, 5)            //Blood
-            LOADOUT_ITEM(SOCOMD_notes, 0)
-            LOADOUT_ITEM(ACE_basicAirway, 9)                    //Nasopharangeal Airway
-            LOADOUT_ITEM(ACE_advancedAirway, 6)                    //Laryngeal Mask Airway
-            LOADOUT_ITEM(ACE_pocketBVM, 1)                //Medical Suction
-            LOADOUT_ITEM(ACE_Pulseoximeter, 4)            //Pulseoximeter
-            LOADOUT_ITEM(SOCOMD_NDC, 6)                    //14 Gauge needle
-            LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
-            LOADOUT_ITEM(ACE_surgicalKit, 8)            //Surgical Kit
-            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
+            LOADOUT_BACKPACK_MEDIC
         };
     };
 };

--- a/addons/loadouts/configs/loadouts/loadouts_lowvis.hpp
+++ b/addons/loadouts/configs/loadouts/loadouts_lowvis.hpp
@@ -345,7 +345,7 @@ class SOCOMD_LOWVIS_Medic {
             LOADOUT_ITEM(SOCOMD_NDC, 6)                    //14 Gauge needle
             LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
             LOADOUT_ITEM(ACE_surgicalKit, 8)            //Surgical Kit
-            LOADOUT_ITEM(kat_AED, 1)        //Defibrillator
+            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
         };
     };
 };
@@ -405,7 +405,7 @@ class SOCOMD_LOWVIS_AO{
             LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
             LOADOUT_ITEM(SOCOMD_NDC, 8)                    //14 Gauge needle
             LOADOUT_ITEM(ACE_surgicalKit, 4)            //Surgical Kit
-            LOADOUT_ITEM(kat_aed, 1)                    //Defibrillator
+            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
             LOADOUT_ITEM(ACE_bodyBag, 2)                //Defibrillator
         };
     };

--- a/addons/loadouts/configs/loadouts/loadouts_sso.hpp
+++ b/addons/loadouts/configs/loadouts/loadouts_sso.hpp
@@ -364,36 +364,7 @@ class SOCOMD_SSO_AO{
         type = ITEM_BACKPACK_MEDIC;
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
-            LOADOUT_ITEM(SOCOMD_booboo, 1)
-            LOADOUT_ITEM(ACE_packingBandage, 0)          //Remove
-            LOADOUT_ITEM(ACE_fieldDressing, 15)          //Israeli Bandage
-            LOADOUT_ITEM(ACE_epinephrine, 0)              //Remove
-            LOADOUT_ITEM(ACE_morphine, 0)                  //Remove
-            LOADOUT_ITEM(ACE_personalAidKit, 0)            //Remove
-            LOADOUT_ITEM(ACE_salineIV_500, 0)             //Remove
-            LOADOUT_ITEM(ACE_elasticBandage, 5)            //Elastic Bandage
-            LOADOUT_ITEM(ACE_quikclot, 20)                //Quikclot
-            LOADOUT_ITEM(ACE_chestSeal, 8)                //Hyfin Chest Seal
-            LOADOUT_ITEM(ACE_tourniquet, 6)                //Tourniquet
-            LOADOUT_ITEM(SOCOMD_Epinephrine, 10)        //Epinephrine Ampoule
-            LOADOUT_ITEM(SOCOMD_naloxone, 2)                //Naloxone Ampoule
-            LOADOUT_ITEM(SOCOMD_fentanyl, 4)                //Fentanyl Ampoule
-            LOADOUT_ITEM(SOCOMD_ketamine, 4)        //Ketamine Ampoule
-            LOADOUT_ITEM(SOCOMD_Apap, 10)                    //Paracetamol
-            LOADOUT_ITEM(SOCOMD_nargloves, 5)
-            LOADOUT_ITEM(SOCOMD_Tetra, 0)                //Paracetamol
-            LOADOUT_ITEM(ACE_bloodIV_500, 14)            //Blood
-            LOADOUT_ITEM(SOCOMD_shears, 1)
-            LOADOUT_ITEM(ACE_basicAirway, 0)                    //Nasopharangeal Airway
-            LOADOUT_ITEM(SOCOMD_cascard, 2)
-            LOADOUT_ITEM(ACE_advancedAirway, 6)                    //Laryngeal Mask Airway
-            LOADOUT_ITEM(ACE_pocketBVM, 1)                //Medical Suction
-            LOADOUT_ITEM(ACE_Pulseoximeter, 3)            //Pulseoximeter
-            LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
-            LOADOUT_ITEM(SOCOMD_NDC, 8)                    //14 Gauge needle
-            LOADOUT_ITEM(ACE_surgicalKit, 4)            //Surgical Kit
-            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
-            LOADOUT_ITEM(ACE_bodyBag, 2)                //Defibrillator
+            LOADOUT_BACKPACK_MEDIC
         };
     };
 };

--- a/addons/loadouts/configs/loadouts/loadouts_sso.hpp
+++ b/addons/loadouts/configs/loadouts/loadouts_sso.hpp
@@ -332,7 +332,7 @@ class SOCOMD_SSO_Medic {
             LOADOUT_ITEM(SOCOMD_NDC, 6)                    //14 Gauge needle
             LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
             LOADOUT_ITEM(ACE_surgicalKit, 8)            //Surgical Kit
-            LOADOUT_ITEM(kat_AED, 1)        //Defibrillator
+            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
         };
     };
 };
@@ -392,7 +392,7 @@ class SOCOMD_SSO_AO{
             LOADOUT_ITEM(SOCOMD_VPN, 30)                //3mL drug Syringe
             LOADOUT_ITEM(SOCOMD_NDC, 8)                    //14 Gauge needle
             LOADOUT_ITEM(ACE_surgicalKit, 4)            //Surgical Kit
-            LOADOUT_ITEM(kat_aed, 1)                    //Defibrillator
+            LOADOUT_ITEM(socomd_defib_AED, 1)        //Defibrillator
             LOADOUT_ITEM(ACE_bodyBag, 2)                //Defibrillator
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
Fix missing defibs in lowvis, rus and afp qstore loadouts