### PR TITLE
Qwerty medical

### DIFF
--- a/addons/loadouts/configs/loadouts/default.hpp
+++ b/addons/loadouts/configs/loadouts/default.hpp
@@ -12,16 +12,13 @@
     LOADOUT_ITEM(ACE_epinephrine, 0) \
     LOADOUT_ITEM(ACE_morphine, 2) \
     LOADOUT_ITEM(ACE_tourniquet, 2) \
-    LOADOUT_ITEM(SOCOMD_Apap, 3) \
-    LOADOUT_ITEM(ACE_packingBandage, 0) \
-    LOADOUT_ITEM(ACE_fieldDressing, 4)  \
+    LOADOUT_ITEM(ACE_packingBandage, 8) \
     LOADOUT_ITEM(ACE_chestSeal, 1)    \
-    LOADOUT_ITEM(SOCOMD_NDC, 1)    \
-    LOADOUT_ITEM(ACE_basicAirway, 2)
+    LOADOUT_ITEM(kat_guedel, 2)
 
 #define LOADOUT_UNIFORM_ESSENTIALS \
     LOADOUT_ITEM(ItemAndroid, 1) \
-    LOADOUT_ITEM(ItemcTabHCam, 0) \
+    LOADOUT_ITEM(ItemcTabHCam, 1) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_MapTools, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
@@ -31,7 +28,7 @@
 
 #define LOADOUT_COMMANDER_ESSENTIALS \
     LOADOUT_ITEM(ItemcTab, 1) \
-    LOADOUT_ITEM(ItemcTabHCam, 0) \
+    LOADOUT_ITEM(ItemcTabHCam, 1) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_MapTools, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
@@ -42,13 +39,13 @@
 
 #define LOADOUT_UNIFORM_AO_ESSENTIALS \
     LOADOUT_ITEM(ItemAndroid, 1) \
-    LOADOUT_ITEM(ItemcTabHCam, 0) \
+    LOADOUT_ITEM(ItemcTabHCam, 1) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
     LOADOUT_ITEM(ACWP_18Rnd_9x21_Mag_USP, 2)
 
 #define LOADOUT_PILOT_ESSENTIALS \
-    LOADOUT_ITEM(ItemcTabHCam, 0) \
+    LOADOUT_ITEM(ItemcTabHCam, 1) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_MapTools, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
@@ -87,7 +84,7 @@
 // COMMON JAC LOADOUT ITEMS
 
 #define LOADOUT_SUPPORT_ESSENTIALS \
-    LOADOUT_ITEM(ItemcTabHCam, 0) \
+    LOADOUT_ITEM(ItemcTabHCam, 1) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
     LOADOUT_ITEM(SOCOMD_GPNVG18b_BLK_F, 1) \
@@ -103,44 +100,27 @@
     LOADOUT_ITEM(ACE_epinephrine, 0) \
     LOADOUT_ITEM(ACE_morphine, 1) \
     LOADOUT_ITEM(ACE_tourniquet, 2) \
-    LOADOUT_ITEM(SOCOMD_Apap, 4) \
-    LOADOUT_ITEM(ACE_packingBandage, 0) \
+    LOADOUT_ITEM(ACE_packingBandage, 8) \
     LOADOUT_ITEM(ACE_fieldDressing, 0) \
-    LOADOUT_ITEM(SOCOMD_VPN, 1)
 
 #define LOADOUT_BACKPACK_MEDIC \
-    LOADOUT_ITEM(SOCOMD_booboo, 0)\
-    LOADOUT_ITEM(SOCOMD_shears, 0)\
-    LOADOUT_ITEM(ACE_packingBandage, 0)\
-    LOADOUT_ITEM(ACE_fieldDressing, 20)\
-    LOADOUT_ITEM(SOCOMD_triangleban, 0)\
-    LOADOUT_ITEM(ACE_epinephrine, 0)\
-    LOADOUT_ITEM(ACE_morphine, 0)\
-    LOADOUT_ITEM(ACE_personalAidKit, 0)\
-    LOADOUT_ITEM(ACE_salineIV_500, 0)\
-    LOADOUT_ITEM(SOCOMD_cascard, 0)\
+    LOADOUT_ITEM(ACE_packingBandage, 20)\
+    LOADOUT_ITEM(ACE_epinephrine, 10)\
+    LOADOUT_ITEM(ACE_morphine, 10)\
     LOADOUT_ITEM(ACE_elasticBandage, 20)  \
-    LOADOUT_ITEM(ACE_quikclot, 25)        \
-    LOADOUT_ITEM(ACE_chestSeal, 6)        \
-    LOADOUT_ITEM(SOCOMD_nargloves, 0)     \
+    LOADOUT_ITEM(ACE_quikclot, 20)        \
+    LOADOUT_ITEM(kat_chestSeal, 6)        \
     LOADOUT_ITEM(ACE_tourniquet, 6)       \
-    LOADOUT_ITEM(SOCOMD_Epinephrine, 10)  \
-    LOADOUT_ITEM(SOCOMD_naloxone, 2)      \
-    LOADOUT_ITEM(SOCOMD_fentanyl, 8)      \
-    LOADOUT_ITEM(SOCOMD_ketamine, 8)      \
-    LOADOUT_ITEM(SOCOMD_Apap, 10)         \
-    LOADOUT_ITEM(SOCOMD_Tetra, 0)         \
+    LOADOUT_ITEM(kat_naloxone, 2)      \
     LOADOUT_ITEM(ACE_bloodIV_500, 5)      \
-    LOADOUT_ITEM(SOCOMD_notes, 0)         \
-    LOADOUT_ITEM(ACE_basicAirway, 9)      \
-    LOADOUT_ITEM(ACE_advancedAirway, 6)   \
-    LOADOUT_ITEM(ACE_pocketBVM, 1)        \
-    LOADOUT_ITEM(ACE_pulseOximeter, 4)    \
-    LOADOUT_ITEM(SOCOMD_NDC, 6)           \
-    LOADOUT_ITEM(SOCOMD_VPN, 30)          \
+    LOADOUT_ITEM(kat_guedel, 9)      \
+    LOADOUT_ITEM(kat_larynx, 6)   \
+    LOADOUT_ITEM(kat_pulseOximeter, 4)    \
     LOADOUT_ITEM(ACE_surgicalKit, 8)      \
-    LOADOUT_ITEM(socomd_defib_AED, 1)     \
-    LOADOUT_ITEM(ACE_bodyBag, 2)
+    LOADOUT_ITEM(kat_AED, 1)     \
+    LOADOUT_ITEM(ACE_bodyBag, 2)\
+    LOADOUT_ITEM(kat_accuvac, 1)
+
 
 //////////////////////////////////////////////////////////////////////
 //Individual loadout items
@@ -273,7 +253,7 @@ class SOCOMD_TACP {
             LOADOUT_ITEM(SmokeShellGreen, 4)
             LOADOUT_ITEM(ACE_HuntIR_M203, 3)
             LOADOUT_ITEM(SmokeShellPurple, 4)
-            LOADOUT_ITEM(B_IR_Grenade,5)
+            LOADOUT_ITEM(B_IR_Grenade, 5)
             LOADOUT_ITEM(1Rnd_SmokeRed_Grenade_shell, 6)
         };
     };
@@ -366,8 +346,7 @@ class SOCOMD_Rifleman {
         type = ITEM_BACKPACK_RIFLEMAN;
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
-            LOADOUT_ITEM(ACE_Clacker, 1) 
-            LOADOUT_ITEM(ACE_M26_Clacker, 1)
+            LOADOUT_BACKPACK_CHARGES
             LOADOUT_ITEM(ACE_EntrenchingTool, 1)
         };
     };

--- a/addons/loadouts/configs/loadouts/default.hpp
+++ b/addons/loadouts/configs/loadouts/default.hpp
@@ -13,7 +13,7 @@
     LOADOUT_ITEM(ACE_morphine, 2) \
     LOADOUT_ITEM(ACE_tourniquet, 2) \
     LOADOUT_ITEM(ACE_packingBandage, 8) \
-    LOADOUT_ITEM(ACE_chestSeal, 1)    \
+    LOADOUT_ITEM(ACE_chestSeal, 1) \
     LOADOUT_ITEM(kat_guedel, 2)
 
 #define LOADOUT_UNIFORM_ESSENTIALS \
@@ -101,24 +101,24 @@
     LOADOUT_ITEM(ACE_morphine, 1) \
     LOADOUT_ITEM(ACE_tourniquet, 2) \
     LOADOUT_ITEM(ACE_packingBandage, 8) \
-    LOADOUT_ITEM(ACE_fieldDressing, 0) \
+    LOADOUT_ITEM(ACE_fieldDressing, 0)
 
 #define LOADOUT_BACKPACK_MEDIC \
-    LOADOUT_ITEM(ACE_packingBandage, 20)\
-    LOADOUT_ITEM(ACE_epinephrine, 10)\
-    LOADOUT_ITEM(ACE_morphine, 10)\
-    LOADOUT_ITEM(ACE_elasticBandage, 20)  \
-    LOADOUT_ITEM(ACE_quikclot, 20)        \
-    LOADOUT_ITEM(kat_chestSeal, 6)        \
-    LOADOUT_ITEM(ACE_tourniquet, 6)       \
-    LOADOUT_ITEM(kat_naloxone, 2)      \
-    LOADOUT_ITEM(ACE_bloodIV_500, 5)      \
-    LOADOUT_ITEM(kat_guedel, 9)      \
-    LOADOUT_ITEM(kat_larynx, 6)   \
-    LOADOUT_ITEM(kat_pulseOximeter, 4)    \
-    LOADOUT_ITEM(ACE_surgicalKit, 8)      \
-    LOADOUT_ITEM(kat_AED, 1)     \
-    LOADOUT_ITEM(ACE_bodyBag, 2)\
+    LOADOUT_ITEM(ACE_packingBandage, 20) \
+    LOADOUT_ITEM(ACE_epinephrine, 10) \
+    LOADOUT_ITEM(ACE_morphine, 10) \
+    LOADOUT_ITEM(ACE_elasticBandage, 20) \
+    LOADOUT_ITEM(ACE_quikclot, 20) \
+    LOADOUT_ITEM(kat_chestSeal, 6) \
+    LOADOUT_ITEM(ACE_tourniquet, 6) \
+    LOADOUT_ITEM(kat_naloxone, 2)  \
+    LOADOUT_ITEM(ACE_bloodIV_500, 5) \
+    LOADOUT_ITEM(kat_guedel, 9) \
+    LOADOUT_ITEM(kat_larynx, 6) \
+    LOADOUT_ITEM(kat_pulseOximeter, 4) \
+    LOADOUT_ITEM(ACE_surgicalKit, 8) \
+    LOADOUT_ITEM(kat_AED, 1) \
+    LOADOUT_ITEM(ACE_bodyBag, 2) \
     LOADOUT_ITEM(kat_accuvac, 1)
 
 

--- a/addons/loadouts/configs/loadouts/default.hpp
+++ b/addons/loadouts/configs/loadouts/default.hpp
@@ -18,7 +18,7 @@
 
 #define LOADOUT_UNIFORM_ESSENTIALS \
     LOADOUT_ITEM(ItemAndroid, 1) \
-    LOADOUT_ITEM(ItemcTabHCam, 1) \
+    LOADOUT_ITEM(ItemcTabHCam, 0) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_MapTools, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
@@ -28,7 +28,7 @@
 
 #define LOADOUT_COMMANDER_ESSENTIALS \
     LOADOUT_ITEM(ItemcTab, 1) \
-    LOADOUT_ITEM(ItemcTabHCam, 1) \
+    LOADOUT_ITEM(ItemcTabHCam, 0) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_MapTools, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
@@ -39,13 +39,13 @@
 
 #define LOADOUT_UNIFORM_AO_ESSENTIALS \
     LOADOUT_ITEM(ItemAndroid, 1) \
-    LOADOUT_ITEM(ItemcTabHCam, 1) \
+    LOADOUT_ITEM(ItemcTabHCam, 0) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
     LOADOUT_ITEM(ACWP_18Rnd_9x21_Mag_USP, 2)
 
 #define LOADOUT_PILOT_ESSENTIALS \
-    LOADOUT_ITEM(ItemcTabHCam, 1) \
+    LOADOUT_ITEM(ItemcTabHCam, 0) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_MapTools, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
@@ -84,7 +84,7 @@
 // COMMON JAC LOADOUT ITEMS
 
 #define LOADOUT_SUPPORT_ESSENTIALS \
-    LOADOUT_ITEM(ItemcTabHCam, 1) \
+    LOADOUT_ITEM(ItemcTabHCam, 0) \
     LOADOUT_ITEM(ACE_EarPlugs, 1) \
     LOADOUT_ITEM(ACE_Flashlight_KSF1, 1) \
     LOADOUT_ITEM(SOCOMD_GPNVG18b_BLK_F, 1) \
@@ -346,7 +346,8 @@ class SOCOMD_Rifleman {
         type = ITEM_BACKPACK_RIFLEMAN;
         class Inventory    {
             LOADOUT_BACKPACK_ESSENTIALS
-            LOADOUT_BACKPACK_CHARGES
+            LOADOUT_ITEM(ACE_Clacker, 1) 
+            LOADOUT_ITEM(ACE_M26_Clacker, 1)
             LOADOUT_ITEM(ACE_EntrenchingTool, 1)
         };
     };


### PR DESCRIPTION
Removes socomd custom medical supplies and adds default ace+kat in line with qwerty cbasettings. Lots can be tweaked/added, talk to qwerty if you need it done.
